### PR TITLE
unicorn 1.6.2 LTS (161rk3)

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,28 +11,31 @@ Slade Watkins <watkins@wallymer.com>
 
 \\ Huge thank you to all of our wonderful developers and maintainers <3
 
-Adam Alexander <adamalex@wallymer.com>
+Adam Alexander <madarazzi@wallymer.com>
+Alexander, Adam <madarazzi@mail-int.wallymer.com>
 alexander hodge <alexhodge@wallymer.com>
 alexander hodge <ahodg@git.wallymer.com>
-alexander hodge <hodge@onetwentyfour.net>
 Allen WBS <allenwbs@git.wallymer.com>
+Archam Archambault <archam@wallymer.com>
+Archambault, Owen "Archam" (Exchange) <archam@mail-int.wallymer.com>
+Barnes, Logan (Exchange) <loganba@mail-int.wallymer.com>
 Boblin Bot <boblincr@dvi.onetwentyfour.net>
 Boblin Bot - Git Connector (upstreamed code) <boblinupstreamed@git.wallymer.com>
-Owen "Archam" Archambault <owenar@onetwentyfour.net>
-Owen "Archam" Archambault <archam@wallymer.com>
-Owen "Archam" Archambault <archam@git.wallymer.com>
 Faith Barnes <faithbarnes@wallymer.com>
 Faith Barnes <faithbarnes@git.wallymer.com>
 Dave Efrenc <daveefrenc@wallymer.com>
-Davis Efrenc <efrencd@wallymer.com>
-Davis Efrenc <efrencd@dvi.onetwentyfour.net>
-Davis Efrenc <efrencd@git.wallymer.com>
-Keith G <keith@git.wallymer.com>
+Dave Efrenc Jr <efrencd@wallymer.com>
+dave efrenc git <efrencd@git.wallymer.com>
+Efrenc, Dave (Exchange) <efrencd@mail-int.wallymer.com>
+K Garfield <kgarf@wallymer.com>
+K Garfield <kgarf@git.wallymer.com>
+Keith G <keith@wallymer.com>
 Lance "Loc" OC <lanceoc@wallymer.com> 
 Lance "Loc" OC <lanceoc@git.wallymer.com>
 Logan Barnes <loganba@wallymer.com>
 Logan O'Conner <logocon@wallymer.com>
 Logan O'Conner (git) <logocon@git.wallymer.com>
+Owen Archambault <archam@git.wallymer.com>
 Sherlock - Bug Detective <sherlock@git.wallymer.com>
 Slade Watkins <slade@sladewatkins.com>
 Slade Watkins <watkins@wallymer.com>

--- a/docs/api/release-targets.md
+++ b/docs/api/release-targets.md
@@ -16,4 +16,5 @@ NC = No API changes in this release
 | 1.6.5 | Planned | 163 (NC) |
 | 1.6.4 | Alpha | 163 (NC) |
 | 1.6.3 | Beta | 163 |
+| 1.6.2 LTS | Stable | 161 (NC) |
 | 1.6.2 | Stable | 161 (NC) |

--- a/docs/releases/lifecycle.md
+++ b/docs/releases/lifecycle.md
@@ -8,16 +8,16 @@ ___
 ## Currently Supported InDev Builds
 | Channel | OS Version | Build | Date Released | Support End Date | LTS? | Architecture |
 |---------|------------|------------------|---------------|------------------|------|------------|
-| Alpha  | 1.6.4   | u164x86_64-alpha  | December 4, 2021 | To be determined | No | x86_64   |
-| Beta  | 1.6.4-x86-LTS  | ults164x86-alpha    | December 4, 2021 | To be determined | Yes | x86 |
-| Beta  | 1.6.3    | u163x86_64-beta  | December 4, 2021 | To be determined | No | x86_64   |
-| Beta  | 1.6.3-x86-LTS  | ults163x86-beta    | December 4, 2021 | To be determined | Yes | x86 |
+| Alpha  | 1.6.4 (x86_64) Alpha | 163rk2  | December 4, 2021 | To be determined | No | x86_64   |
+| Alpha  | 1.6.4 LTS Alpha | 163rl2   | December 4, 2021 | To be determined | Yes | x86 |
+| Beta  | 1.6.3 (x86_64) Beta | 163rk1  | December 4, 2021 | To be determined | No | x86_64   |
+| Beta  | 1.6.3 LTS Beta | 163rl1 | December 4, 2021 | To be determined | Yes | x86 |
 
 ## Currently Supported Stable Builds
 | Channel | OS Version | Build | Date Released | Support End Date | LTS? | Architecture |
 |---------|------------|------------------|---------------|------------------|------|------------|
-| Stable  | 1.6.2     | u162x86_64-master  | December 4, 2021 | To be determined | No | x86_64   |
-| Stable | 1.6.2-x86-LTS | ults-162x86-master | December 4, 2021 | March 1, 2021 (^) | Yes | x86 |
+| Stable  | 1.6.2 (x86_64) | 161rk2 | December 4, 2021 | To be determined | No | x86_64   |
+| Stable | 1.6.2 LTS | 161rl3 | December 13, 2021 | March 1, 2021 (^) | Yes | x86 |
 
 (^) Stable LTS builds are supplemented by point releases (x.x) and are supported until at least this date, after which, you will be able to upgrade to the next LTS release (which comes out around every three months).
 
@@ -28,9 +28,4 @@ We are no longer showing **all** of these directly on the doc in order to reduce
 
 | Channel | OS Version | Build | Date Released | Support End Date | LTS? | Architecture |
 |---------|------------|------------------|---------------|------------------|------|------------|
-| Beta  | 1.6.2     | u162x86_64-beta  | November 28, 2021 | December 3, 2021 | No | x86_64   |
-| Beta  | 1.6.2-x86-LTS    | ults162x86-beta    | November 28, 2021 | December 3, 2021 | Yes | x86 |
-| Stable | 1.6.1       | u161x86_64-master | November 28, 2021 | December 3, 2021 | No | x86_64 | 
-| Stable | 1.6.1-x86   | u161x86-master    | November 28, 2021 | December 3, 2021 | No | x86 |
-| Stable  | 1.5-x86-LTS | ults15-x86-master  | August 31, 2021 | December 3, 2021 | Yes | x86   |
-| Stable  | 1.5-LTS    | ults15-x86_64-master | August 31, 2021 | December 3, 2021 | Yes | x86_64   |
+| Stable | 1.6.2-x86-LTS | 161rl2 | December 4, 2021 | December 12, 2021 | Yes, succeeded by 1.6.2 (161rl3) | x86 |

--- a/docs/releases/notes.md
+++ b/docs/releases/notes.md
@@ -2,12 +2,7 @@
 title: Current Release Notes
 ---
 ## unicorn Alpha Channel
-These releases are currently in-ring and are [supported](/releases/lifecycle/). Please click the build to see its changelog.
-
-| Build String | Arch | OS Version Identifier | Date Released |
-|--------------|------|-----------------------|---------------|
-| [u164x86_64-alpha](#unicorn-1-6-4) | x86_64 | 1.6.4 | December 4, 2021 |
-| [ults164x86-alpha](#unicorn-LTS-1-6-4) | x86 | 1.6.4-x86-LTS | December 4, 2021 |
+These releases are currently in-ring and are [supported](/releases/lifecycle/).
 
 ### unicorn 1.6.4
 | **Released** December 4, 2021 for x86_64 systems |
@@ -17,7 +12,7 @@ These releases are currently in-ring and are [supported](/releases/lifecycle/). 
 - added new integrated controls for Syncfon in the system manager.
 - (Linux) Linux ``kernel`` updated to version ``5.10`` from version ``5.4``.
 
-### unicorn LTS 1.6.4
+### unicorn 1.6.4 LTS
 | **Released** December 4, 2021 for x86 (32-bit) systems |
 |--------------------------------|
 | **Build**: 163rl2 |
@@ -45,7 +40,7 @@ These releases are currently in-ring and are [supported](/releases/lifecycle/). 
 - performance improvements
 - new system requirements announced earlier this year are now enforced.
 
-### unicorn LTS 1.6.3
+### unicorn 1.6.3 LTS
 | **Released** December 4, 2021 for x86 (32-bit) systems |
 |--------------------------------|
 | **Build**: 163rl1 |
@@ -75,9 +70,22 @@ These releases are currently in-ring and are [supported](https://github.com/Wall
 - performance improvements
 - new system requirements announced earlier this year are now enforced.
 
-**x86 build changes**
-| **Build**: 161rl2 |
+### unicorn 1.6.2 LTS
+| **Released** December 13, 2021 |
 |--------------------------------|
+| **Build**: 161rk3 |
+
+- Android security patches for November-December 2021
+- OS security patches for December 2021
+- updated software repositories
+- patched apt to prevent removing the desktop environment (for real this time)
+- Linux kernel updated to stable release of 5.4.164
+
+| **Released** December 4, 2021 |
+|--------------------------------|
+| **Build**: 161rk2 |
+
+**Please update to build 161rk3 for important security fixes.**
 
 - x86 builds are now LTS by default. We plan to service 1.6.x with new x86 builds (with the latest security enhancements) until at least February 1, 2022.
 	- Release notes will be separated from x86_64 versions, as LTS support is paused for the architecture.


### PR DESCRIPTION
- Android security patches for November-December 2021
- OS security patches for December 2021
- updated software repositories
- patched apt to prevent removing the desktop environment (for real this time)
- Linux kernel updated to stable release of 5.4.164