### PR TITLE
Pull from next-release: metadata update

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,3 +3,5 @@ This license file is here to inform you that copying, redistributing, or otherwi
 This repository is public for the sake of transparency, though we do allow external users to contribute corrections here and there. Please note that the only credit you will receive will be in commit history and will not be public-facing otherwise.
 
 By contributing to this repository, and its documentation, you agree to the terms as stated herein.
+
+Thank you!

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -20,21 +20,15 @@ Boblin Bot - Git Connector (upstreamed code) <boblinupstreamed@git.wallymer.com>
 cwatson <cwatson@git.wallymer.com>
 Chuck Watson <cwatson@wallymer.com>
 Dave Efrenc <daveefrenc@wallymer.com>
-Dave Efrenc (Git) <daveefrenc@git.wallymer.com>
 dmwallace <dmwallace@wallymer.com>
-D M Wallace <dmwallace@git.wallymer.com>
 Efrenc, Dave (Exchange) <daveefrenc@mint.wallymer.com>
 Harry <hh@wallymer.com>
-hh git <hh@git.wallymer.com>
 Holmes - PR Bot <holmes@git.wallymer.com>
 K Garfield <kgarf@wallymer.com>
-K Garfield <kgarf@git.wallymer.com>
 Logan Barnes <loganba@wallymer.com>
-Logan O'Conner (git) <logocon@git.wallymer.com>
+Logan O'Conner <logocon@wallymer.com>
 Malik O'Leary <moleary@wallymer.com>
 Owen Archambault <archam@git.wallymer.com>
-O'Conner, Logan (Exchange) <logocon@mint.wallymer.com>
-O'Leary, Malik (Exchange) <moleary@mint.wallymer.com>
 reefback <watkins@git.wallymer.com>
 Sherlock - Bug Detective <sherlock@git.wallymer.com>
 Slade Watkins <slade@sladewatkins.com>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -12,15 +12,12 @@ Slade Watkins <watkins@wallymer.com>
 \\ Huge thank you to all of our wonderful developers and maintainers <3
 
 Adam Alex <madarazzi@wallymer.com>
-Archam Archambault <archam@wallymer.com>
-Archambault, Owen "Archam" (Exchange) <archam@mint.wallymer.com>
 Barnes, Logan (Exchange) <loganba@mint.wallymer.com>
 Boblin Bot - Code Review <boblincode@git.wallymer.com>
 Boblin Bot - Git Connector (upstreamed code) <boblinupstreamed@git.wallymer.com>
-cwatson <cwatson@git.wallymer.com>
 Chuck Watson <cwatson@wallymer.com>
 Dave Efrenc <daveefrenc@wallymer.com>
-dmwallace <dmwallace@wallymer.com>
+Denim Wallace <dnmwallace@wallymer.com>
 Efrenc, Dave (Exchange) <daveefrenc@mint.wallymer.com>
 Harry <hh@wallymer.com>
 Holmes - PR Bot <holmes@git.wallymer.com>
@@ -28,7 +25,8 @@ K Garfield <kgarf@wallymer.com>
 Logan Barnes <loganba@wallymer.com>
 Logan O'Conner <logocon@wallymer.com>
 Malik O'Leary <moleary@wallymer.com>
-Owen Archambault <archam@git.wallymer.com>
+Owen Archambault <owenar@onetwentyfour.net>
+Owen Archambault <archam@wallymer.com>
 reefback <watkins@git.wallymer.com>
 Sherlock - Bug Detective <sherlock@git.wallymer.com>
 Slade Watkins <slade@sladewatkins.com>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -12,12 +12,15 @@ Slade Watkins <watkins@wallymer.com>
 \\ Huge thank you to all of our wonderful developers and maintainers <3
 
 Adam Alex <madarazzi@wallymer.com>
+Archam Archambault <archam@wallymer.com>
+Archambault, Owen "Archam" (Exchange) <archam@mint.wallymer.com>
 Barnes, Logan (Exchange) <loganba@mint.wallymer.com>
 Boblin Bot - Code Review <boblincode@git.wallymer.com>
 Boblin Bot - Git Connector (upstreamed code) <boblinupstreamed@git.wallymer.com>
+cwatson <cwatson@git.wallymer.com>
 Chuck Watson <cwatson@wallymer.com>
 Dave Efrenc <daveefrenc@wallymer.com>
-Denim Wallace <dnmwallace@wallymer.com>
+dmwallace <dmwallace@wallymer.com>
 Efrenc, Dave (Exchange) <daveefrenc@mint.wallymer.com>
 Harry <hh@wallymer.com>
 Holmes - PR Bot <holmes@git.wallymer.com>
@@ -25,8 +28,7 @@ K Garfield <kgarf@wallymer.com>
 Logan Barnes <loganba@wallymer.com>
 Logan O'Conner <logocon@wallymer.com>
 Malik O'Leary <moleary@wallymer.com>
-Owen Archambault <owenar@onetwentyfour.net>
-Owen Archambault <archam@wallymer.com>
+Owen Archambault <archam@git.wallymer.com>
 reefback <watkins@git.wallymer.com>
 Sherlock - Bug Detective <sherlock@git.wallymer.com>
 Slade Watkins <slade@sladewatkins.com>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 ## unicorn Development Version Docs Repo
 This is the repository where we host our documentation site's source material. If you're interested in helping us make corrections, please feel free to open an issue or pull request!
 
-Please see the LICENSE.md file for more information on this repository.
+Please see the [LICENSE](LICENSE.md file for more information on this repository.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 ## unicorn Development Version Docs Repo
 This is the repository where we host our documentation site's source material. If you're interested in helping us make corrections, please feel free to open an issue or pull request!
 
-Please see the [LICENSE](LICENSE.md file for more information on this repository.
+Please see the LICENSE.md file for more information on this repository.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 ## unicorn Development Version Docs Repo
 This is the repository where we host our documentation site's source material. If you're interested in helping us make corrections, please feel free to open an issue or pull request!
 
-Please see the [LICENSE](LICENSE.md file for more information on this repository.
+Please see the [LICENSE](LICENSE.md) file for more information on this repository.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 To report a vulnerability with our site, you've come to the right place. First, check which release is [most current](https://github.com/Wallymer/unicorndocs/releases).  
-We only fix site vulnerabilities for the three (3) most recent **production** (green) releases. (Pre-release documentation is not supported since that it doesn't get pushed to the live site.)  
+We only fix site vulnerabilities for the two (2) most recent **production** (green) releases. (Pre-release documentation is not supported since those are not publicly available, and thus, do not get pushed to the production site.)  
 
 For reference purposes, the five (5) most recent are shown here.
 
@@ -10,10 +10,10 @@ For reference purposes, the five (5) most recent are shown here.
 | ------- | ------------------ |
 | 12-18-2021 | :heavy_check_mark:
 | 12-15-2021b | :heavy_check_mark: |
-| 12-15-2021 | :heavy_check_mark: |
+| 12-15-2021 | :x: |
 | 12-14-2021 | :x: |
 | 12-13-2021 | :x: |
 
 ## Reporting a Vulnerability
 
-To report a vulnerability, please reach out to [wallymer@wallymer.com](mailto:wallymer@wallymer.com). **Please send your email in plain text. HTML emails are NOT permitted.**
+To report a vulnerability, please reach out to [wallymer@wallymer.com](mailto:wallymer@wallymer.com). **Please send your email in plain text. HTML emails are NOT permitted for security reasons.**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,2 +1,2 @@
-site_name: toffeeOS Docs
+site_name: toffeeOS Docs (Beta)
 theme: material


### PR DESCRIPTION

Signed-off-by: Slade Watkins <slade@sladewatkins.com>
Signed-off-by: Denim Wallace <dnmwallace@wallymer.com>
Signed-off-by: Chuck Watson <cwatson@wallymer.com>
Acked-by: Faith Barnes <faithbarnes@wallymer.com>

﻿- updating security policy
- fixed and updated README (pulled from cwatson/unicorndocs/main)
- Revert "fixed and updated README (pulled from cwatson/unicorndocs/main)"
- pull cwatson tree for ReadMe Update (properly signed this time)
- remove most git.wallymer.com email addresses from MAINTAINERS
- remove last few git.wallymer.com emails, fix Denim's email
- Revert "remove last few git.wallymer.com emails, fix Denim's email"
- correct author attribution
- indicate Beta due to instability of the site
- update License (added line at bottom thanking users)
- fix broken link to LICENSE file
