### PR TITLE
2022-A2: tracking dev cycle

### DIFF
--- a/.GITURLSINTERNAL
+++ b/.GITURLSINTERNAL
@@ -1,2 +1,6 @@
-git://git.vpn.wallymer.com/toffeeos/docs.git
-git://github.com/Wallymer/unicorndocs.git
+git://wallace.vpn.wallymer.com/toffeeos/docs.git
+git://gromit.vpn.wallymer.com/toffeeos/docs.git
+git://shaun.vpn.onetwentyfour.net/toffeeos/docs.git
+git://bitzer.vpn.onetwentyfour.net/toffeeos/docs.git
+git://git.internal.wallymer.com/toffeeos/docs.git
+git://git.internal.onetwentyfour.net/toffeeos/docs.git

--- a/.GITURLSINTERNAL
+++ b/.GITURLSINTERNAL
@@ -1,0 +1,2 @@
+git://git.vpn.wallymer.com/toffeeos/docs.git
+git://github.com/Wallymer/unicorndocs.git

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: Build Documentation using MkDocs
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Build and Deploy Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Master
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs-material
+
+      - name: Deploy
+        run: |
+          git pull
+          mkdocs gh-deploy

--- a/AUTOMATICBUILD.md
+++ b/AUTOMATICBUILD.md
@@ -1,3 +1,3 @@
-This repository autobuilds pull requests to the ``master`` branch.
+This repository automatically builds pull requests to the ``master`` branch.
 
 You can see the source website files at [Wallymer/unicorndocssite](https://github.com/Wallymer/unicorndocssite).

--- a/AUTOMATICBUILD.md
+++ b/AUTOMATICBUILD.md
@@ -1,0 +1,3 @@
+This repository autobuilds pull requests to the ``master`` branch.
+
+You can see the source website files at [Wallymer/unicorndocssite](https://github.com/Wallymer/unicorndocssite).

--- a/COMMITS
+++ b/COMMITS
@@ -1,0 +1,7 @@
+Commits to this repository MUST _under all circumstances_ be signed by a verified key beginning December 31, 2021.
+
+To do just that, use the web editor on GitHub.com **or** please follow the guides linked here:
+https://docs.github.com/en/authentication/managing-commit-signature-verification
+
+Thanks,
+Wallymer Team

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -1,7 +1,0 @@
-Commits to this repository MUST _under all circumstances_ be signed by a verified key beginning December 31, 2021.
-
-To do just that, use the web editor on GitHub.com **or** please follow the guides linked here: 
-[https://docs.github.com/en/authentication/managing-commit-signature-verification](https://docs.github.com/en/authentication/managing-commit-signature-verification)
-
-Thanks,  
-Wallymer Team

--- a/DOCSRELEASE
+++ b/DOCSRELEASE
@@ -1,4 +1,4 @@
-docs version: 2022-A2-pre2
+docs version: 2022-A2-pre3
 date: 01-12-2022
 
 details: https://github.com/Wallymer/unicorndocs/blob/main/VERSIONING.md

--- a/DOCSRELEASE
+++ b/DOCSRELEASE
@@ -1,4 +1,4 @@
-docs version: 2022-A2-pre1
+docs version: 2022-A2-pre2
 date: 01-12-2022
 
 details: https://github.com/Wallymer/unicorndocs/blob/main/VERSIONING.md

--- a/DOCSRELEASE
+++ b/DOCSRELEASE
@@ -1,4 +1,4 @@
-docs version: 01-07-2022 (amended)
-date: 01-07-2022 (Jan 7, 2022), amended Jan 11, 2022
+docs version: 2022-A2 (do not push to prerel yet)
+date: 01-12-2022
 
 details: https://github.com/Wallymer/unicorndocs/blob/main/VERSIONING.md

--- a/DOCSRELEASE
+++ b/DOCSRELEASE
@@ -1,4 +1,4 @@
-docs version: 2022-A2 (do not push to prerel yet)
+docs version: 2022-A2-pre1
 date: 01-12-2022
 
 details: https://github.com/Wallymer/unicorndocs/blob/main/VERSIONING.md

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,12 +1,14 @@
 Documentation Maintainers:
-Slade Watkins <slade@sladewatkins.com>
-Slade Watkins <watkins@wallymer.com>
+Slade Watkins <slade@sladewatkins.com> <watkins@wallymer.com>
+Charles Boulder <chrlsb@wallymer.com> <chuck_boulder@wallymer.com>
+Chuck Watson <cwatson@wallymer.com>
 
 \\ **Most addresses in this file are internal only and emails sent to them will bounce.
 \\ Please reach out to watkins@wallymer.com if you'd like to confirm someone's contact info so you can get in touch.**
 
 \\ Huge thank you to all of our wonderful developers and maintainers <3
 
+MAP:
 Adam Alex <madarazzi@wallymer.com>
 Boblin Bot - Code Review <boblin-code-review@wallymer.com>
 Boblin Bot - toffeeOS Upstream <boblin-toffeeos-upstreamed@wallymer.com>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,11 +8,11 @@ For reference purposes, the five (5) most recent are shown here.
 
 | Releases | Supported?          |
 | ------- | ------------------ |
+| [01-DD-2022](https://github.com/Wallymer/unicorndocs/tree/prod/01-DD-2022) | :heavy_check_mark: |
 | [01-07-2022](https://github.com/Wallymer/unicorndocs/tree/prod/01-07-2022) | :heavy_check_mark: |
-| [12-20-2021](https://github.com/Wallymer/unicorndocs/tree/prod/12-20-2021) | :heavy_check_mark: |
+| [12-20-2021](https://github.com/Wallymer/unicorndocs/tree/prod/12-20-2021) | :x |
 | [12-18-2021c](https://github.com/Wallymer/unicorndocs/tree/prod/12-18-2021c) | :x: |
 | [12-18-2021](https://github.com/Wallymer/unicorndocs/tree/prod/12-18-2021) | :x: |
-| [12-15-2021b](https://github.com/Wallymer/unicorndocs/tree/prod/12-15-2021b) | :x: |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,13 +6,13 @@ We only fix site vulnerabilities for the two (2) most recent **production** (gre
 
 For reference purposes, the five (5) most recent are shown here.
 
-| Releases | Supported          |
+| Releases | Supported?          |
 | ------- | ------------------ |
-| 01-07-2022 | :heavy_check_mark: |
-| 12-20-2021 | :heavy_check_mark: |
-| 12-18-2021c | :x: |
-| 12-18-2021 | :x: |
-| 12-15-2021b | :x: |
+| [01-07-2022](https://github.com/Wallymer/unicorndocs/tree/prod/01-07-2022) | :heavy_check_mark: |
+| [12-20-2021](https://github.com/Wallymer/unicorndocs/tree/prod/12-20-2021) | :heavy_check_mark: |
+| [12-18-2021c](https://github.com/Wallymer/unicorndocs/tree/prod/12-18-2021c) | :x: |
+| [12-18-2021](https://github.com/Wallymer/unicorndocs/tree/prod/12-18-2021) | :x: |
+| [12-15-2021b](https://github.com/Wallymer/unicorndocs/tree/prod/12-15-2021b) | :x: |
 
 ## Reporting a Vulnerability
 

--- a/docs/api/release-targets.md
+++ b/docs/api/release-targets.md
@@ -11,16 +11,16 @@ NC = No API changes in this release
 | 1.9 for ARM | Planned | ``190A`` |
 | 1.9 LTS | Planned | ``190`` |
 | 1.8 for ARM | Planned | ``180A`` |
-| 1.8 and 1.8 LTS | Planned | ``180`` |
+| 1.8 and 1.8 x86-LTS | Planned | ``180`` |
 | 1.7.1 for ARM | Planned | ``170A`` |
-| 1.7 and 1.7 LTS | Planned | ``170`` |
-| 1.6.8 LTS | Planned | ``166`` (NC) |
-| 1.6.7 LTS | Planned | ``166`` (NC) |
-| 1.6.6 LTS | Planned | ``166`` |
-| 1.6.5 LTS | Planned | ``165`` |
+| 1.7 and 1.7 x86-LTS | Planned | ``170`` |
+| 1.6.8 x86-LTS | Planned | ``166`` (NC) |
+| 1.6.7 x86-LTS | Planned | ``166`` (NC) |
+| 1.6.6 x86-LTS | Planned | ``166`` |
+| 1.6.5 x86-LTS | Planned | ``165`` |
 | 1.6.4 | Alpha | ``163`` (NC) |
 | 1.6.3 | Beta | ``163`` |
-| 1.6.2 and 1.6.2 LTS | Stable | ``161`` (NC) |
+| 1.6.2 and 1.6.2 x86-LTS | Stable | ``161`` (NC) |
 
 ## Architecture Codes
 
@@ -28,6 +28,6 @@ These are displayed after the API Level target (as well as in some build/version
 
 | Architecture | Displayed as? |
 |-----------------|-----------------|
-| 32-bit | ``none, uses LTS builds`` |
-| 64-bit | ``none`` |
+| 32-bit (x86) | ``x86-LTS`` |
+| 64-bit (x86_64) | ``none`` |
 | ARM | ``A`` |

--- a/docs/api/release-targets.md
+++ b/docs/api/release-targets.md
@@ -13,7 +13,7 @@ NC = No API changes in this release
 | 1.8 for ARM | Planned | ``180A`` |
 | 1.8 and 1.8 LTS | Planned | ``180`` |
 | 1.7.1 for ARM | Planned | ``170A`` |
-| 1.7 and 1.7 LTS | Planned | ``170`` | 
+| 1.7 and 1.7 LTS | Planned | ``170`` |
 | 1.6.8 LTS | Planned | ``166`` (NC) |
 | 1.6.7 LTS | Planned | ``166`` (NC) |
 | 1.6.6 LTS | Planned | ``166`` |
@@ -23,8 +23,11 @@ NC = No API changes in this release
 | 1.6.2 and 1.6.2 LTS | Stable | ``161`` (NC) |
 
 ## Architecture Codes
+
+These are displayed after the API Level target (as well as in some build/version strings).
+
 | Architecture | Displayed as? |
 |-----------------|-----------------|
 | 32-bit | ``none, uses LTS builds`` |
 | 64-bit | ``none`` |
-| ARM | ``###A`` |
+| ARM | ``A`` |

--- a/docs/releases/kernel.md
+++ b/docs/releases/kernel.md
@@ -1,9 +1,12 @@
 ## Kernel Versions
 
+We tend to only use long-term support (LTS) releases of the Linux kernel with the limited exceptions being the ARM releases of toffeeOS Dev Version, and short-term beta tests.
+
 | toffeeOS Dev Version | Linux kernel version |
 |------------|----------------------|
 | 1.9 | ``5.15.y`` |
 | 1.8 | ``5.15.y`` |
+| 1.7.1 for ARM | ``5.16.y`` |
 | 1.7 | ``5.10.y`` |
 | 1.6.5 (x86_64) | ``5.10.y`` |
 | 1.6.5 LTS (x86) | ``5.4.y`` |

--- a/docs/releases/kernel.md
+++ b/docs/releases/kernel.md
@@ -4,10 +4,10 @@ We tend to only use long-term support (LTS) releases of the Linux kernel with th
 
 | toffeeOS Dev Version | Linux kernel version |
 |------------|----------------------|
-| 1.9 | ``5.15.y`` |
-| 1.8 | ``5.15.y`` |
+| 1.9 and 1.9 LTS | ``5.15.y`` |
+| 1.8 and 1.8 LTS | ``5.15.y`` |
 | 1.7.1 for ARM | ``5.16.y`` |
-| 1.7 | ``5.10.y`` |
+| 1.7 and 1.7 LTS | ``5.10.y`` |
 | 1.6.5 (x86_64) | ``5.10.y`` |
 | 1.6.5 LTS (x86) | ``5.4.y`` |
-| 1.3-1.6.4 | ``5.4.y`` |
+| 1.3-1.6.4 (including LTS) | ``5.4.y`` |

--- a/docs/releases/lifecycle.md
+++ b/docs/releases/lifecycle.md
@@ -8,16 +8,16 @@ ___
 ## Currently Supported InDev Builds
 | Channel | OS Version | Build | Date Released | Support End Date | LTS? | Architecture |
 |---------|------------|------------------|---------------|------------------|------|------------|
-| Alpha  | 1.6.4 (x86_64) Alpha | 163rk2  | December 4, 2021 | To be determined | No | x86_64   |
-| Alpha  | 1.6.4 LTS Alpha | 163rl2   | December 4, 2021 | To be determined | Yes | x86 |
-| Beta  | 1.6.3 (x86_64) Beta | 163rk1  | December 4, 2021 | To be determined | No | x86_64   |
-| Beta  | 1.6.3 LTS Beta | 163rl1 | December 4, 2021 | To be determined | Yes | x86 |
+| Alpha | 1.6.5 (x86_64) | 165rk1 | January 12, 2022 | To be determined | No | x86_64 |
+| Alpha | 1.6.5 (x86) LTS | 165rl1 | January 12, 2022 | March 1, 2021 (^) | Yes | x86 |
+| Beta | 1.6.4 (x86_64) | 163rk4 | January 12, 2022 | To be determined | No | x86_64 |
+| Beta | 1.6.4 (x86) LTS | 163rl2 | January 12, 2022 | March 1, 2021 (^) | Yes | x86 |
 
 ## Currently Supported Stable Builds
 | Channel | OS Version | Build | Date Released | Support End Date | LTS? | Architecture |
 |---------|------------|------------------|---------------|------------------|------|------------|
-| Stable  | 1.6.2 (x86_64) | 161rk2 | December 4, 2021 | To be determined | No | x86_64   |
-| Stable | 1.6.2 LTS | 161rl3 | December 13, 2021 | March 1, 2021 (^) | Yes | x86 |
+| Stable  | 1.6.3 (x86_64) | 163rk2b | January 12, 2022 | To be determined | No | x86_64   |
+| Stable | 1.6.3 (x86) LTS | 163rl1 | January 12, 2022 | March 1, 2021 (^) | Yes | x86 |
 
 (^) Stable LTS builds are supplemented by point releases (x.x) and are supported until at least this date, after which, you will be able to upgrade to the next LTS release (which comes out around every three months).
 
@@ -28,4 +28,7 @@ We are no longer showing **all** of these directly on the doc in order to reduce
 
 | Channel | OS Version | Build | Date Released | Support End Date | LTS? | Architecture |
 |---------|------------|------------------|---------------|------------------|------|------------|
-| Stable | 1.6.2-x86-LTS | 161rl2 | December 4, 2021 | December 12, 2021 | Yes, succeeded by 1.6.2 (161rl3) | x86 |
+| Alpha  | 1.6.4 (x86_64) Alpha | 163rk2  | December 4, 2021 | January 12, 2022 | No | x86_64   |
+| Alpha  | 1.6.4 LTS Alpha | 163rl2   | December 4, 2021 | January 12, 2022 | Yes | x86 |
+| Beta  | 1.6.3 (x86_64) Beta | 163rk1  | December 4, 2021 | January 12, 2022 | No | x86_64   |
+| Beta  | 1.6.3 LTS Beta | 163rl1 | December 4, 2021 | January 12, 2022 | Yes | x86 |

--- a/docs/releases/notes.md
+++ b/docs/releases/notes.md
@@ -1,67 +1,67 @@
 ---
 title: Current Release Notes
 ---
-## toffeeOS Dev Version Alpha Channel
+
+## toffeeOS Dev Version - Alpha Channel
 These releases are currently in-ring and are [supported](/releases/lifecycle/).
 
-### toffeeOS Dev Version 1.6.4
-| **Released** December 14, 2021 for x86_64 systems |
+### toffeeOS 1.6.5
+| **Released** January 12, 2022 for x86_64 (64-bit) systems |
 |--------------------------------|
-| **Build**: 163rk3 |
+| **Build**: 165rk1 |
+| **LTS Support Ends On** March 1, 2021 (Stable) |
 
-64-bit only.  
+- bug fixes
 
-- System: December security patches
-- Android Subsystem: security updates for November-December 2021
-
-| **Released** December 4, 2021 for x86_64 systems |
+### toffeeOS 1.6.5 (x86) LTS
+| **Released** January 12, 2022 for x86 (32-bit) systems |
 |--------------------------------|
-| **Build**: 163rk2 | 
+| **Build**: 165rl1 |
+| **LTS Support Ends On** March 1, 2021 (Stable) |
 
-**Please update to build 163rk3 for important fixes.**
+- bug fixes
+
+
+## toffeeOS Dev Version - Beta Channel
+These releases are currently in-ring and are [supported](/releases/lifecycle/). 
+
+
+### toffeeOS 1.6.4
+| **Released** January 12, 2022 for x86_64 (64-bit) systems |
+|--------------------------------|
+| **Build**: 165rk1 |
+| **LTS Support Ends On** March 1, 2021 (Stable) |
 
 - added new integrated controls for Syncfon in the system manager.
 - (Linux) Linux ``kernel`` updated to version ``5.10`` from version ``5.4``.
 
-### toffeeOS Dev Version 1.6.4 LTS
-| **Released** December 4, 2021 for x86 (32-bit) systems |
+### toffeeOS 1.6.4 (x86) LTS
+| **Released** January 12, 2022 for x86 (32-bit) systems |
 |--------------------------------|
-| **Build**: 163rl2 |
+| **Build**: 165rl1 |
 | **LTS Support Ends On** March 1, 2021 (Stable) |
 
 - (Linux) unicorn LTS 1.6.4 remains on Linux ``kernel`` version ``5.4``.
 - deprecated `syncfon` package officially for 32-bit systems.
 
-## toffeeOS Dev Version Beta Channel
+
+## toffeeOS Dev Version - Stable Channel
 These releases are currently in-ring and are [supported](/releases/lifecycle/). 
 
-### toffeeOS Dev Version 1.6.3
-| **Released** December 15, 2021 for x86_64 systems |
+### toffeeOS 1.6.3
+| **Released** January 12, 2022 for x86_64 (64-bit) systems |
 |--------------------------------|
 | **Build**: 163rk2b |
-
-64-bit only. x86 (32-bit) systems already have the latest fixes included in this update.
-
-- bug fixes
-	- fixed system instability bug with storing files on spinning media (hard drives) under the deprecated ext3 file system. 
-- System: December security patches
-- Android Subsystem: security updates for November-December 2021
-
-| **Released** December 4, 2021 for x86_64 systems |
-|--------------------------------------------------|
-| **Build**: 163rk1 |
-
-**Please update to build 163rk2b for important fixes.**
 
 - bug fixes
 	- this release fixes an issue with UX in the Settings app
 	- this release fixes an issue where, in some cases, Syncfon would crash upon automatic sync with a narwhal client device.
 	- this release addresses an issue with `apt` and the graphical package manager that allowed users to effectively destroy `unicorn-desktop` (and all related) packages, removing access to their desktop environment.
-- performance improvements
-- new system requirements announced earlier this year are now enforced.
+	- this release fixed a system instability bug with storing files on spinning media (hard drives) under the deprecated ext3 file system. 
+- also: some major performance improvements
 
-### toffeeOS Dev Version 1.6.3 LTS
-| **Released** December 4, 2021 for x86 (32-bit) systems |
+### toffeeOS 1.6.3 (x86) LTS
+| **Released** January 12, 2022 for x86 (32-bit) systems |
 |--------------------------------------------------------|
 | **Build**: 163rl1 |
 | **LTS Support Ends On** March 1, 2021 (Stable) |
@@ -70,42 +70,3 @@ These releases are currently in-ring and are [supported](/releases/lifecycle/).
 - bug fixes
 	- this release fixes an issue with UX in the Settings app
 	- this release addresses an issue with `apt` and the graphical package manager that allowed users to effectively destroy `unicorn-desktop` (and all related) packages, removing access to their desktop environment.
-
-## toffeeOS Dev Version Stable Channel
-These releases are currently in-ring and are [supported](/releases/lifecycle/).
-
-### toffeeOS Dev Version 1.6.2
-| **Released** December 4, 2021 |
-|--------------------------------|
-| **Build**: 161rk2 |
-
-- bug fixes
-	- this release fixes an issue with UX in the Settings app
-	- this release fixes an issue where, in some cases, Syncfon would crash upon automatic sync with a narwhal client device.
-- performance improvements
-- new system requirements announced earlier this year are now enforced.
-
-### toffeeOS Dev Version 1.6.2 LTS
-| **Released** December 13, 2021 |
-|--------------------------------|
-| **Build**: 161rk3 |
-
-- Android security patches for November-December 2021
-- OS security patches for December 2021
-- updated software repositories
-- patched apt to prevent removing the desktop environment (for real this time)
-- Linux kernel updated to stable release of 5.4.164
-
-| **Released** December 4, 2021 |
-|--------------------------------|
-| **Build**: 161rk2 |
-
-**Please update to build 161rk3 for important security fixes.**
-
-- x86 builds are now LTS by default. We plan to service 1.6.x with new x86 builds (with the latest security enhancements) until at least February 1, 2022.
-	- Release notes will be separated from x86_64 versions, as LTS support is paused for the architecture.
-	- LTS versions will be branded as "unicorn LTS"
-- Server Communicator has been removed from the x86 build.
-- users enrolled in a server environment on x86 builds of unicorn will have their user accounts converted into local ones.
-- users enrolled in a server environment on x86 builds of unicorn will be prompted to contact their administrators about switching to an x86_64 (64-bit) build.
-- Enterprise Mode and Education Mode have been deprecated and are no longer supported on x86 builds. Switch to a x86_64 (64-bit) build to continue receiving support after January 1, 2022. **Updates will continue per the x86 build deprecation timeline.**

--- a/docs/releases/notes.md
+++ b/docs/releases/notes.md
@@ -25,11 +25,10 @@ These releases are currently in-ring and are [supported](/releases/lifecycle/).
 ## toffeeOS Dev Version - Beta Channel
 These releases are currently in-ring and are [supported](/releases/lifecycle/). 
 
-
 ### toffeeOS 1.6.4
 | **Released** January 12, 2022 for x86_64 (64-bit) systems |
 |--------------------------------|
-| **Build**: 165rk1 |
+| **Build**: 163rk4 |
 | **LTS Support Ends On** March 1, 2021 (Stable) |
 
 - added new integrated controls for Syncfon in the system manager.
@@ -38,7 +37,7 @@ These releases are currently in-ring and are [supported](/releases/lifecycle/).
 ### toffeeOS 1.6.4 (x86) LTS
 | **Released** January 12, 2022 for x86 (32-bit) systems |
 |--------------------------------|
-| **Build**: 165rl1 |
+| **Build**: 163rl2 |
 | **LTS Support Ends On** March 1, 2021 (Stable) |
 
 - (Linux) unicorn LTS 1.6.4 remains on Linux ``kernel`` version ``5.4``.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,2 +1,2 @@
-site_name: toffeeOS Docs (Beta)
+site_name: toffeeOS Dev Version Docs
 theme: material


### PR DESCRIPTION
- [x] new releases to their trees
       - 1.6.5 (x86_64) Alpha
       - 1.6.5 LTS (x86) Alpha
       - 1.6.4 (x86_64) Beta
       - 1.6.4 LTS (x86) Beta
       - 1.6.3 (x86_64) Stable
       - 1.6.3 LTS (x86) Stable
- [x] security patches
- [x] update documentation for 1.6.5 (x86_64) Alpha and 1.6.5 LTS (x86) Alpha